### PR TITLE
Three state toggle with icon change

### DIFF
--- a/yarudarkthemetoggle@feichtmeier.me/extension.js
+++ b/yarudarkthemetoggle@feichtmeier.me/extension.js
@@ -5,17 +5,26 @@ const Gio = imports.gi.Gio;
 const Main = imports.ui.main;
 const PanelMenu = imports.ui.panelMenu;
 
-const LABEL_TEXT = 'Toggle dark theme';
-
+const LABEL_TEXT = 'Toggle Yaru variants';
 const SCHEMA_KEY = 'org.gnome.desktop.interface';
 const THEME_KEY = 'gtk-theme';
-const LIGHT_THEME = 'Yaru';
-const DARK_THEME = 'Yaru-dark';
 
-let button, settings;
+var button, settings, themes, icon;
+
+function theme_node(name, icon, next=null) {
+    this.name = name;
+    this.icon = icon;
+    this.next = next;
+}
 
 function init() {
 	settings = new Gio.Settings({ schema: SCHEMA_KEY });
+    var yaru_light = new theme_node('Yaru-light', 'weather-clear-symbolic');
+    var yaru_dark = new theme_node('Yaru-dark', 'weather-clear-night-symbolic', yaru_light);
+    var yaru = new theme_node('Yaru', 'weather-few-clouds-symbolic', yaru_dark);
+    yaru_light.next = yaru;
+
+    themes = [ yaru, yaru_dark, yaru_light ];
 }
 
 function toggleTheme() {
@@ -24,18 +33,35 @@ function toggleTheme() {
         return;
     }
 
-	const newTheme = curTheme === LIGHT_THEME ? DARK_THEME : LIGHT_THEME;
-	settings.set_string(THEME_KEY, newTheme);
+    var theme;
+    for (theme of themes) {
+        if (!(theme.name === curTheme)) {
+            continue;
+        }
+        settings.set_string(THEME_KEY, theme.next.name);
+        icon.icon_name = theme.next.icon;
+    }
 }
 
 function enable() {
-	button = new PanelMenu.Button(0.0);
+    var curTheme = settings.get_string(THEME_KEY);
+    var icon_name = 'weather-clear-night-symbolic';
 
-	const icon = new St.Icon({
-		icon_name: 'weather-clear-night-symbolic',
+    if (curTheme.includes('Yaru')) {
+        var theme;
+        for (theme of themes) {
+            if (theme.name === curTheme) {
+                icon_name = theme.icon;
+            }
+        }
+    }
+
+	icon = new St.Icon({
+		icon_name: icon_name,
 		style_class: 'system-status-icon'
 	});
 
+	button = new PanelMenu.Button(0.0);
 	button.actor.add_actor(icon);
 	button.actor.connect('button-press-event', toggleTheme);
 	Main.panel.addToStatusArea('ToggleDarkTheme', button);

--- a/yarudarkthemetoggle@feichtmeier.me/extension.js
+++ b/yarudarkthemetoggle@feichtmeier.me/extension.js
@@ -19,10 +19,12 @@ function init() {
 }
 
 function toggleTheme() {
-	const newTheme = settings.get_string(THEME_KEY) === LIGHT_THEME
-		? DARK_THEME
-		: LIGHT_THEME;
+    const curTheme = settings.get_string(THEME_KEY);
+    if (!curTheme || !curTheme.includes('Yaru')) {
+        return;
+    }
 
+	const newTheme = curTheme === LIGHT_THEME ? DARK_THEME : LIGHT_THEME;
 	settings.set_string(THEME_KEY, newTheme);
 }
 


### PR DESCRIPTION
~If current theme is not Yaru, do nothing.~

Sorry, I wanted to propose two different changes, but the latest one includes the first, so here is just one PR.

- add three state toggle (Yaru, Yaru-light, Yaru-dark)
- add logic to set different icon for each selected theme (current icons are only an example, better design some new ones)
- add logic to load dynamically the appropriate icon for the currently selected theme


![yaru-shell-extension-eoan](https://user-images.githubusercontent.com/2883614/65587592-67b46c80-df86-11e9-82f7-284d053c02be.gif)

