### PR TITLE
Generic theme toggle

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,8 +3,8 @@ version: '1.0'
 summary: Yaru Dark Theme Toggle
 description: Toggles between Yaru and Yaru-dark
 
-grade: stable  
-confinement: classic 
+grade: stable
+confinement: classic
 base: core18
 
 parts:

--- a/yarudarkthemetoggle@feichtmeier.me/extension.js
+++ b/yarudarkthemetoggle@feichtmeier.me/extension.js
@@ -8,6 +8,11 @@ const PanelMenu = imports.ui.panelMenu;
 const LABEL_TEXT = 'Toggle Yaru variants';
 const SCHEMA_KEY = 'org.gnome.desktop.interface';
 const THEME_KEY = 'gtk-theme';
+const THEME_DIR = '/usr/share/themes/';
+const LIGHT_ICON = 'weather-clear-symbolic';
+const DARK_ICON = 'weather-clear-night-symbolic';
+/* For Yaru only */
+const DAWN_ICON = 'weather-few-clouds-symbolic';
 
 var button, settings, themes, icon;
 
@@ -19,35 +24,30 @@ function theme_node(name, icon, next=null) {
 
 function init() {
 	settings = new Gio.Settings({ schema: SCHEMA_KEY });
-    var yaru_light = new theme_node('Yaru-light', 'weather-clear-symbolic');
-    var yaru_dark = new theme_node('Yaru-dark', 'weather-clear-night-symbolic', yaru_light);
-    var yaru = new theme_node('Yaru', 'weather-few-clouds-symbolic', yaru_dark);
-    yaru_light.next = yaru;
-
-    themes = [ yaru, yaru_dark, yaru_light ];
 }
 
 function toggleTheme() {
-    const curTheme = settings.get_string(THEME_KEY);
-    if (!curTheme || !curTheme.includes('Yaru')) {
-        return;
-    }
+    var curTheme = settings.get_string(THEME_KEY);
+    themes = build_options();
 
     var theme;
     for (theme of themes) {
         if (!(theme.name === curTheme)) {
             continue;
         }
-        settings.set_string(THEME_KEY, theme.next.name);
-        icon.icon_name = theme.next.icon;
+        if (theme.next) {
+            settings.set_string(THEME_KEY, theme.next.name);
+            icon.icon_name = theme.next.icon;
+        }
     }
 }
 
 function enable() {
     var curTheme = settings.get_string(THEME_KEY);
-    var icon_name = 'weather-clear-night-symbolic';
+    var icon_name = LIGHT_ICON;
 
     if (curTheme.includes('Yaru')) {
+        themes = build_options();
         var theme;
         for (theme of themes) {
             if (theme.name === curTheme) {
@@ -69,5 +69,47 @@ function enable() {
 
 function disable() {
 	button.destroy();
+}
+
+function build_options() {
+    var curTheme = settings.get_string(THEME_KEY);
+    if (!curTheme) {
+        return [];
+    }
+
+    if (curTheme.includes('Yaru')) {
+        if (themes && themes[0].name.includes('Yaru')) {
+            // themes already configured
+            return themes;
+        }
+
+        var yaru_light = new theme_node('Yaru-light', LIGHT_ICON);
+        var yaru_dark = new theme_node('Yaru-dark', DARK_ICON, yaru_light);
+        var yaru = new theme_node('Yaru', DAWN_ICON, yaru_dark);
+        yaru_light.next = yaru;
+
+        return [yaru, yaru_dark, yaru_light];
+    }
+
+    // default both variants to current theme
+    var light = new theme_node(curTheme, LIGHT_ICON);
+    var dark = new theme_node(curTheme, LIGHT_ICON, light);
+    light.next = dark;
+
+    var stem = curTheme;
+    if (curTheme.endsWith('-dark')) {
+        stem = curTheme.substring(0, curTheme.lastIndexOf('-'));
+    }
+
+    if (Gio.File.new_for_path(THEME_DIR.concat(stem)).query_exists(null)) {
+        light.name = stem;
+    }
+
+    if (Gio.File.new_for_path(THEME_DIR.concat(stem).concat('-dark')).query_exists(null)) {
+        dark.name = stem.concat('-dark');
+        dark.icon = DARK_ICON;
+    }
+
+    return [light, dark];
 }
 


### PR DESCRIPTION
If current theme is Yaru, allow three state toggle as previous version, otherwise check if
current theme has a light/dark variant and toggle among those.

Tested with:
- Yaru
- Adwaita
- Materia

Not working with
- Arc (to be investigated)